### PR TITLE
Spelling clarifications

### DIFF
--- a/docs/style-conventions.md
+++ b/docs/style-conventions.md
@@ -137,7 +137,7 @@ We prioritize simplicity over comprehensiveness. If you can't find a particular 
     - Use commas to separate main clauses.
     - Use a comma before *such as*.
     - Use a comma after *for example*.
-    - Use the Oxford comma for *and* and *or* conjunctions.
+    - Use the Oxford comma for *and* and *or* conjunctions where the meaning of your sentence would otherwise be unclear. In other cases, avoid placing the extra comma.
 - Use these guidelines for periods:
     - Use a period at the end of a sentence, including sentences ending on a [URL](#links).
     - Observe the punctuation rules for items on a [bullet list](#bullet-lists).
@@ -543,9 +543,20 @@ Modal verbs are auxiliary verbs that modify the meaning of the main verb in a se
     | **Correct** | Here you can find the list of keyboard shortcuts.                      |
     | Incorrect   | In the following section, you can find the list of keyboard shortcuts. |
 
-## Common words usage
+## Spelling
 
-- For spelling differences among English dialects, adhere to the most widely used dialect.
+Use the Oxford spelling.
+
+- Use the suffix *-ize* instead of *-ise*. As such, write *organize* and *organization*, not *organise* and *organisation*.
+- The rule above doesn't affect the spelling of words ending in *-yse*, such as *analyse*.
+- Some examples of the Oxford spelling include: globalization, behaviour, centre, defence, catalogue, programme.
+- If in doubt of any spelling, feel free to use the [Cambridge Dictionary][cambridge-dictionary]{:target="_blank"}.
+
+## Word choice
+
+Write in Global and Plain English.
+
+- Don't use words that can be confusing for non-native speakers. For more details, see the [A-Z of alternative words :octicons-tab-external-16:][plain-english-alternative-words]{:target="_blank"} composed by the Plain English Campaign.
 - Don't use Latin abbreviations like *e.g.*, *etc.* or *i.e.* Use an English equivalent, like *for example*, *and so on*, or *that is*.
 - This list summarizes some common words and terms:
 

--- a/docs/style-guidelines.md
+++ b/docs/style-guidelines.md
@@ -38,7 +38,7 @@ When creating technical content for Status, consider these guidelines:
 - Don't use cultural or local expressions, made-up words, figurative language, obscure acronyms, metaphors, or (needless to say) discriminatory language. Write for a general audience without considering factors such as race, ethnicity, religion, nationality, or gender.
 - Don't assume the reader has prior knowledge of a new concept when introducing it. Instead, explain the idea in simple terms and provide readers with resources or related topics to find out more.
 - We don't obsess over grammar rules. Language isn't an exact science, and different style guides use different conventions. This guide follows the rule commonly accepted, disregarding exceptions.
-- Status documentation adheres to the most widely used English dialect.
+- Status documentation should be written in Global English using Oxford spelling.
 
 <br>[:octicons-git-branch-24: Contribute to our docs][contributors-guide]{ .md-button }</br>
 


### PR DESCRIPTION
Hello! 

I:
1. Edited the Oxford comma punctuation guideline.
2. Added a spelling section, providing more details about the Oxford spelling.
3. Added a word choice section in place of 'Common words usage', which built upon the latter to also include mentions of the Plain English vocabulary list and the so-called 'Global English' dialect.

I haven't yet configured the URL shortcuts, since some of the links may have to go as we are reviewing the document. Happy to hear any feedback or further improvement suggestions!